### PR TITLE
Add Travel Log modal for quick multi-prefecture visit entry

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { LogOut, User, MapPin, Table, ExternalLink, Sun, Moon, Monitor, Search, Share2 } from "lucide-react";
+import { LogOut, User, MapPin, Table, ExternalLink, Sun, Moon, Monitor, Search, Share2, NotebookPen } from "lucide-react";
 import Image from 'next/image';
 import { motion, AnimatePresence } from "motion/react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -17,6 +17,7 @@ import { ShareModal } from '@/components/share-modal';
 import { SettingsModal } from '@/components/settings-modal';
 import { AnimatedHeaderItem } from '@/components/ui/animated-header-item';
 import { PrefectureManagementModal } from '@/components/prefecture-management-modal';
+import { TravelLogModal } from '@/components/travel-log-modal';
 import { usePrefectureSearch } from '@/hooks/usePrefectureSearch';
 
 // Dynamic imports for heavy components
@@ -33,6 +34,7 @@ const StatsDashboard = dynamic(() => import('@/components/stats-dashboard').then
 export default function Home() {
   const [showShareModal, setShowShareModal] = useState(false);
   const [showSettingsModal, setShowSettingsModal] = useState(false);
+  const [showTravelLogModal, setShowTravelLogModal] = useState(false);
   const [selectedRegion, setSelectedRegion] = useState<string | null>(null);
   const [selectedVisitId, setSelectedVisitId] = useState<string | undefined>(undefined);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -44,6 +46,7 @@ export default function Home() {
   const [isSignOutHovered, setIsSignOutHovered] = useState(false);
   const [isThemeHovered, setIsThemeHovered] = useState(false);
   const [isShareHovered, setIsShareHovered] = useState(false);
+  const [isTravelLogHovered, setIsTravelLogHovered] = useState(false);
   const [isSearchExpanded, setIsSearchExpanded] = useState(false);
   const [logoClickCount, setLogoClickCount] = useState(0);
   const [showEasterEgg, setShowEasterEgg] = useState(false);
@@ -329,6 +332,17 @@ export default function Home() {
               </motion.div>
 
               <AnimatedHeaderItem
+                isHovered={isTravelLogHovered}
+                onHoverStart={() => setIsTravelLogHovered(true)}
+                onHoverEnd={() => setIsTravelLogHovered(false)}
+                onClick={() => setShowTravelLogModal(true)}
+                icon={<NotebookPen className="w-4 h-4 text-emerald-600 dark:text-emerald-400" />}
+                label="Travel Log"
+                bgColor="bg-emerald-100 dark:bg-emerald-900/50"
+                textColor="text-emerald-600 dark:text-emerald-400"
+              />
+
+              <AnimatedHeaderItem
                 isHovered={isShareHovered}
                 onHoverStart={() => setIsShareHovered(true)}
                 onHoverEnd={() => setIsShareHovered(false)}
@@ -462,9 +476,14 @@ export default function Home() {
         onCloseAction={() => setShowShareModal(false)} 
       />
       
-      <SettingsModal 
-        isOpen={showSettingsModal} 
-        onClose={() => setShowSettingsModal(false)} 
+      <SettingsModal
+        isOpen={showSettingsModal}
+        onClose={() => setShowSettingsModal(false)}
+      />
+
+      <TravelLogModal
+        open={showTravelLogModal}
+        onClose={() => setShowTravelLogModal(false)}
       />
       
       {/* Easter Egg */}

--- a/components/travel-log-modal.tsx
+++ b/components/travel-log-modal.tsx
@@ -1,0 +1,273 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { toast } from 'sonner';
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { useSupabaseVisits } from '@/contexts/SupabaseVisitsContext';
+import { japanPrefectures, japanRegionGroups } from '@/data/japan';
+import { RATING_LABELS, VisitRating } from '@/types';
+import { NotebookPen, Plus, Trash2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface TravelLogModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+interface LogEntry {
+  tempId: string;
+  regionId: string; // '' until the user picks a prefecture
+  year: string;
+  rating: VisitRating;
+  notes: string;
+}
+
+const getRatingColor = (rating: VisitRating) => {
+  const colors = {
+    0: 'bg-gray-100 text-gray-700',
+    1: 'bg-red-100 text-red-700',
+    2: 'bg-orange-100 text-orange-700',
+    3: 'bg-yellow-100 text-yellow-700',
+    4: 'bg-green-100 text-green-700',
+    5: 'bg-blue-100 text-blue-700',
+  };
+  return colors[rating];
+};
+
+const createEntry = (): LogEntry => ({
+  tempId: `entry-${Date.now()}-${Math.random()}`,
+  regionId: '',
+  year: new Date().getFullYear().toString(),
+  rating: 1, // Default to "Passed through" (skip "Never been")
+  notes: '',
+});
+
+export function TravelLogModal({ open, onClose }: TravelLogModalProps) {
+  const { addVisit, getVisitsByRegion } = useSupabaseVisits();
+  const [entries, setEntries] = useState<LogEntry[]>([createEntry()]);
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  // Reset the form each time the modal opens.
+  useEffect(() => {
+    if (open) {
+      setEntries([createEntry()]);
+      setError('');
+    }
+  }, [open]);
+
+  const addEntry = () => setEntries(prev => [...prev, createEntry()]);
+
+  const removeEntry = (tempId: string) => {
+    setEntries(prev => (prev.length === 1 ? [createEntry()] : prev.filter(e => e.tempId !== tempId)));
+  };
+
+  const updateEntry = (tempId: string, field: keyof LogEntry, value: string | number) => {
+    setEntries(prev => prev.map(e => (e.tempId === tempId ? { ...e, [field]: value } : e)));
+  };
+
+  const handleSave = async () => {
+    setError('');
+    const currentYear = new Date().getFullYear();
+
+    // Per-row validation
+    for (const entry of entries) {
+      if (!entry.regionId) {
+        setError('Please choose a prefecture for every row.');
+        return;
+      }
+      const year = parseInt(entry.year);
+      if (!year || year < 1900 || year > currentYear + 10) {
+        const region = japanPrefectures.regions.find(r => r.id === entry.regionId);
+        setError(`Enter a valid year (1900–${currentYear + 10}) for ${region?.name ?? 'each visit'}.`);
+        return;
+      }
+    }
+
+    // Duplicate prefecture + year within this batch
+    const seen = new Set<string>();
+    for (const entry of entries) {
+      const key = `${entry.regionId}-${entry.year}`;
+      if (seen.has(key)) {
+        const region = japanPrefectures.regions.find(r => r.id === entry.regionId);
+        setError(`Duplicate entry: ${region?.name ?? 'prefecture'} in ${entry.year} appears more than once.`);
+        return;
+      }
+      seen.add(key);
+    }
+
+    // Duplicate against visits that already exist
+    for (const entry of entries) {
+      const year = parseInt(entry.year);
+      const existing = getVisitsByRegion(entry.regionId).some(v => v.visit_year === year);
+      if (existing) {
+        const region = japanPrefectures.regions.find(r => r.id === entry.regionId);
+        setError(`You already have a visit for ${region?.name ?? 'this prefecture'} in ${entry.year}.`);
+        return;
+      }
+    }
+
+    setSaving(true);
+    try {
+      await Promise.all(
+        entries.map(entry =>
+          addVisit(entry.regionId, 'japan', entry.rating, parseInt(entry.year), entry.notes.trim() || undefined)
+        )
+      );
+      toast.success(`Logged ${entries.length} visit${entries.length === 1 ? '' : 's'}`);
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save visits');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={() => onClose()}>
+      <DialogContent className="sm:max-w-4xl max-h-[80vh] overflow-y-auto dark:bg-gray-800">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 dark:text-gray-100">
+            <NotebookPen className="w-5 h-5" />
+            <span>Travel Log</span>
+          </DialogTitle>
+          <DialogDescription className="dark:text-gray-300">
+            Quickly log one or more visits across any prefectures — no need to pick them on the map first.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          <div className="border border-gray-200 dark:border-gray-600 rounded-lg overflow-hidden">
+            <Table>
+              <TableHeader>
+                <TableRow className="bg-gray-50 dark:bg-gray-700">
+                  <TableHead className="w-56 dark:text-gray-200">Prefecture</TableHead>
+                  <TableHead className="w-24 dark:text-gray-200">Year</TableHead>
+                  <TableHead className="w-44 dark:text-gray-200">Visit Type</TableHead>
+                  <TableHead className="dark:text-gray-200">Notes</TableHead>
+                  <TableHead className="w-16 dark:text-gray-200">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {entries.map(entry => (
+                  <TableRow key={entry.tempId} className="dark:border-gray-600">
+                    <TableCell>
+                      <Select
+                        value={entry.regionId}
+                        onValueChange={value => updateEntry(entry.tempId, 'regionId', value)}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="Select prefecture" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {japanRegionGroups.map(group => (
+                            <SelectGroup key={group.name}>
+                              <SelectLabel>
+                                {group.name} ({group.nameJapanese})
+                              </SelectLabel>
+                              {group.regionIds.map(regionId => {
+                                const region = japanPrefectures.regions.find(r => r.id === regionId);
+                                if (!region) return null;
+                                return (
+                                  <SelectItem key={region.id} value={region.id}>
+                                    <span>
+                                      {region.name}
+                                      {region.nameJapanese && (
+                                        <span className="text-xs text-muted-foreground ml-1">
+                                          {region.nameJapanese}
+                                        </span>
+                                      )}
+                                    </span>
+                                  </SelectItem>
+                                );
+                              })}
+                            </SelectGroup>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </TableCell>
+                    <TableCell>
+                      <Input
+                        type="number"
+                        value={entry.year}
+                        onChange={e => updateEntry(entry.tempId, 'year', e.target.value)}
+                        className="w-20"
+                        min="1900"
+                        max={new Date().getFullYear() + 10}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Select
+                        value={entry.rating.toString()}
+                        onValueChange={value => updateEntry(entry.tempId, 'rating', parseInt(value))}
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {(Object.keys(RATING_LABELS) as unknown as VisitRating[])
+                            .filter(rating => parseInt(rating.toString()) !== 0)
+                            .map(rating => (
+                              <SelectItem key={rating} value={rating.toString()}>
+                                <div className="flex items-center gap-2">
+                                  <div className={cn('w-3 h-3 rounded', getRatingColor(rating))} />
+                                  {RATING_LABELS[rating]}
+                                </div>
+                              </SelectItem>
+                            ))}
+                        </SelectContent>
+                      </Select>
+                    </TableCell>
+                    <TableCell>
+                      <Input
+                        value={entry.notes}
+                        onChange={e => updateEntry(entry.tempId, 'notes', e.target.value)}
+                        placeholder="Optional notes..."
+                        className="w-full"
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => removeEntry(entry.tempId)}
+                        className="text-red-600 hover:text-red-700 p-1"
+                        title="Remove row"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          <Button onClick={addEntry} variant="outline" className="w-full">
+            <Plus className="w-4 h-4 mr-2" />
+            Add another visit
+          </Button>
+
+          {error && (
+            <div className="text-red-600 dark:text-red-400 text-sm bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">
+              {error}
+            </div>
+          )}
+
+          <div className="flex gap-2 justify-end">
+            <Button variant="outline" onClick={onClose} disabled={saving}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? 'Saving...' : `Save ${entries.length} visit${entries.length === 1 ? '' : 's'}`}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/data/japan.ts
+++ b/data/japan.ts
@@ -69,3 +69,16 @@ export const japanPrefectures: Country = {
     { id: "okinawa", name: "Okinawa", nameJapanese: "沖縄県", code: "47" }
   ]
 };
+
+// Geographic groupings of the prefectures, in the same order they appear above.
+// Used to group the prefecture dropdown in the travel log by region.
+export const japanRegionGroups: { name: string; nameJapanese: string; regionIds: string[] }[] = [
+  { name: "Hokkaido", nameJapanese: "北海道", regionIds: ["hokkaido"] },
+  { name: "Tohoku", nameJapanese: "東北", regionIds: ["aomori", "iwate", "miyagi", "akita", "yamagata", "fukushima"] },
+  { name: "Kanto", nameJapanese: "関東", regionIds: ["ibaraki", "tochigi", "gunma", "saitama", "chiba", "tokyo", "kanagawa"] },
+  { name: "Chubu", nameJapanese: "中部", regionIds: ["niigata", "toyama", "ishikawa", "fukui", "yamanashi", "nagano", "gifu", "shizuoka", "aichi"] },
+  { name: "Kansai", nameJapanese: "関西", regionIds: ["mie", "shiga", "kyoto", "osaka", "hyogo", "nara", "wakayama"] },
+  { name: "Chugoku", nameJapanese: "中国", regionIds: ["tottori", "shimane", "okayama", "hiroshima", "yamaguchi"] },
+  { name: "Shikoku", nameJapanese: "四国", regionIds: ["tokushima", "kagawa", "ehime", "kochi"] },
+  { name: "Kyushu", nameJapanese: "九州", regionIds: ["fukuoka", "saga", "nagasaki", "kumamoto", "oita", "miyazaki", "kagoshima", "okinawa"] },
+];


### PR DESCRIPTION
Adds a header-launched Travel Log modal that lets users log one or more
visits across any prefectures at once, without selecting them on the map.
Each row has a region-grouped prefecture dropdown, year, visit type, and
notes. Reuses the existing addVisit mutation and validation; no schema
changes needed. Also adds japanRegionGroups grouping data.